### PR TITLE
Return int from main in ann2fig.cpp

### DIFF
--- a/external/ann_1.1.1/ann2fig/ann2fig.cpp
+++ b/external/ann_1.1.1/ann2fig/ann2fig.cpp
@@ -584,7 +584,7 @@ void readANN()
 // procedure.
 //----------------------------------------------------------------------
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 	getArgs(argc, argv);						// get input arguments
 	readANN();									// read the dump file


### PR DESCRIPTION
Fixes the following error:

> ann2fig.cpp:587:1: error: C++ requires a type specifier for all declarations
